### PR TITLE
Point charm-circle schedule at extras/charm-circle.ini

### DIFF
--- a/_data/tv/config/charm-circle.json
+++ b/_data/tv/config/charm-circle.json
@@ -20,7 +20,7 @@
         "tzeithIssurMelakha": { "minutes": 30, "degree": 7.165 }
     },
     "schedule": {
-        "url": "https://malka-minyanim.royzmanim.com/db/charm-circle.db",
+        "url": "https://raw.githubusercontent.com/Zemaneh-Yosef/extras/refs/heads/main/charm-circle.ini",
         "type": "ini"
     }
 }


### PR DESCRIPTION
## What

One line in `_data/tv/config/charm-circle.json`:

```
- "url": "https://malka-minyanim.royzmanim.com/db/charm-circle.db"
+ "url": "https://raw.githubusercontent.com/Zemaneh-Yosef/extras/refs/heads/main/charm-circle.ini"
```

`"type": "ini"` is unchanged, so the screen parses the file exactly as before.

## Why

Charm Circle read its schedule from `malka-minyanim.royzmanim.com`, an external host. Nothing that manages the signage can write there, so that schedule is the one screen nobody can edit without SSH. Moving the source into `extras` makes it editable the same way `ish-matzliach.toml` already is.

## The new file

`Zemaneh-Yosef/extras@cf8f136` added `charm-circle.ini`. It is a byte-for-byte copy of the live `charm-circle.db` with one fix: the `Semichat Chaver<br><i>R' David Rubinov` row opened an `<i>` tag and never closed it.

Checks done before opening this:

- All 4 sections and 21 rows parse, and re-serialising is byte-identical to the source.
- The unclosed `<i>` is the only validation finding; it is gone in the `.ini`.
- `charm-circle.ini` sits at the repo root, so it cannot appear in any carousel — every signage page filters `ls.txt` by a prefix ending in `/` (`./charm-circle/flyer/`, etc.).
- The raw URL above returns 200 with the expected bytes.

## Note

The diff shows 2 additions / 2 deletions rather than 1. The file had no newline at end of file and the GitHub web editor adds one. Nothing else changed.

## Reverting

Revert this PR. `extras/charm-circle.ini` can stay or be deleted; nothing reads it once this is reverted.
